### PR TITLE
Add nose arguments to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,11 @@
 [nosetests]
-verbosity=1
+verbosity=2
+with-spec=true
+spec-color=true
+with-coverage=true
+cover-erase=true
+cover-package=service
+
 
 [coverage:report]
 show_missing = True


### PR DESCRIPTION
Configured nosetests defaults:
- Enabled spec output with color
- Enabled coverage with erase and package scope
